### PR TITLE
feat(trap): support atomic instructions emulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,8 +141,7 @@ dependencies = [
 [[package]]
 name = "riscv-decode"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec7a6dc0b0bb96a4d23271864a45c0d24dcd9dde2a1b630a35f79fa29c588bf"
+source = "git+https://github.com/fintelia/riscv-decode.git?rev=349b2a6b9fa608fc427aa46eaef8935557510d28#349b2a6b9fa608fc427aa46eaef8935557510d28"
 
 [[package]]
 name = "riscv-rt-macros"
@@ -187,7 +186,7 @@ checksum = "a71347da9582cc6b6f3652c7d2c06516c9555690b3738ecdff7e84297f4e17fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -224,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.71"
+version = "2.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
+checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ hpm-rt = { git = "https://github.com/hpm-rs/hpm-rt.git", rev = "66ffb7d7a65d7251
 riscv = "0.10"
 spin = "0.9"
 fast-trap = { version = "0.0.1", features = ["riscv-m"] }
-riscv-decode = "0.2.1"
+riscv-decode = { git = "https://github.com/fintelia/riscv-decode.git", rev = "349b2a6b9fa608fc427aa46eaef8935557510d28" }
 
 [build-dependencies]
 hpm-rt = { git = "https://github.com/hpm-rs/hpm-rt.git", rev = "66ffb7d7a65d7251d0b47db9599d36cefc4d6703" }

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -47,7 +47,7 @@ impl BlobInfo {
     }
 }
 
-pub unsafe fn load_test_kernel() {
+pub unsafe fn load_kernel() {
     let info: &BlobInfo = &BLOB_TABLE[0];
     assert!(info.type_ == BlobType::Kernel);
     assert!(info.start + info.length <= BLOB_TABLE[1].start);

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ fn main() -> ! {
         firmware_address = _start as usize,
     );
     // 初始化 PMP
-    set_pmp();
+    pmp::set_pmp();
     // 显示 PMP 配置
     pmp::print_pmps();
     // 设置陷入栈
@@ -91,18 +91,6 @@ fn main() -> ! {
             trap_handler = sym fast_trap::trap_entry,
             options(noreturn),
         );
-    }
-}
-
-/// 设置 PMP。
-fn set_pmp() {
-    use riscv::register::*;
-    unsafe {
-        // 1. SDRAM
-        pmpcfg0::set_pmp(0, Range::OFF, Permission::NONE, false);
-        pmpaddr0::write((0x4000_0000) >> 2);
-        pmpcfg0::set_pmp(1, Range::TOR, Permission::RWX, false);
-        pmpaddr1::write(usize::MAX >> 2);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,8 @@ fn main() -> ! {
         medeleg::clear_supervisor_env_call();
         medeleg::clear_illegal_instruction();
         medeleg::clear_machine_env_call();
+        medeleg::clear_store_fault();
+        medeleg::clear_load_fault();
         mtvec::write(fast_trap::trap_entry as _, mtvec::TrapMode::Direct);
         asm!("j {trap_handler}",
             trap_handler = sym fast_trap::trap_entry,

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ fn main() -> ! {
     trap_stack::prepare_for_trap();
     unsafe {
         // 加载内核
-        loader::load_test_kernel();
+        loader::load_kernel();
         // 加载设备树
         loader::load_dtb()
     };

--- a/src/pmp.rs
+++ b/src/pmp.rs
@@ -1,4 +1,15 @@
 use crate::println;
+use riscv::register::*;
+
+pub fn set_pmp() {
+    unsafe {
+        // 1. SDRAM
+        pmpcfg0::set_pmp(0, Range::OFF, Permission::NONE, false);
+        pmpaddr0::write((0x4000_0000) >> 2);
+        pmpcfg0::set_pmp(1, Range::TOR, Permission::RWX, false);
+        pmpaddr1::write(usize::MAX >> 2);
+    }
+}
 
 pub(crate) fn print_pmps() {
     const ITEM_PER_CFG: usize = core::mem::size_of::<usize>();
@@ -47,7 +58,6 @@ fn dump_pmp(i: usize, s: usize, e: usize, cfg: usize) {
 }
 
 fn pmpcfg(i: usize) -> usize {
-    use riscv::register::*;
     match i {
         0 => pmpcfg0::read().bits,
         #[cfg(target_arch = "riscv32")]
@@ -60,7 +70,6 @@ fn pmpcfg(i: usize) -> usize {
 }
 
 fn pmpaddr(i: usize) -> usize {
-    use riscv::register::*;
     match i {
         0x0 => pmpaddr0::read(),
         0x1 => pmpaddr1::read(),

--- a/src/riscv_spec.rs
+++ b/src/riscv_spec.rs
@@ -1,7 +1,7 @@
 ﻿#![allow(unused, missing_docs)]
 
-pub const CSR_TIME: u32 = 0xc01;
-pub const CSR_TIMEH: u32 = 0xc81;
+pub const CSR_TIME: usize = 0xc01;
+pub const CSR_TIMEH: usize = 0xc81;
 
 pub mod mie {
     use core::arch::asm;
@@ -101,4 +101,9 @@ pub mod mdcause {
         unsafe { asm!("csrr {}, 0x7c9", out(reg) bits, options(nomem)) };
         bits
     }
+}
+
+#[inline(always)]
+pub unsafe fn fence_i() {
+    core::arch::asm!("fence.i");
 }


### PR DESCRIPTION
Since HPM6360 does not support execute atomic load/store with SDRAM address range, we need to emulation atomic instructions execute in trap handler then the Linux kernel can runs without any modifications and user space thread also is supported.

For AMO instructions, they will trap into Store/AMO access fault exception during execution, so we can emulate it in store fault exception handler.

For `lr/sc` instructions, `lr` will trap into Load access fault during execution but `sc` won't, however. So we need to replace `sc` into an illegal instruction which I use `csrrw zero, time, zero` here, then it will trap into Illegal instruction exception and will be replaced back during exception handling. After replacing instructions we have to execute `fence.i` to make sure this data store is visible to the subsequent instruction fetch.