### PR TITLE
Enable d-cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 [[package]]
 name = "hpm-rt"
 version = "0.1.0"
-source = "git+https://github.com/hpm-rs/hpm-rt.git?rev=66ffb7d7a65d7251d0b47db9599d36cefc4d6703#66ffb7d7a65d7251d0b47db9599d36cefc4d6703"
+source = "git+https://github.com/hpm-rs/hpm-rt.git?rev=f9dd2f2122630ebfa8d9b96f539aba8be1c92784#f9dd2f2122630ebfa8d9b96f539aba8be1c92784"
 dependencies = [
  "cfg-if",
  "r0",
@@ -146,7 +146,7 @@ source = "git+https://github.com/fintelia/riscv-decode.git?rev=349b2a6b9fa608fc4
 [[package]]
 name = "riscv-rt-macros"
 version = "0.2.0"
-source = "git+https://github.com/hpm-rs/hpm-rt.git?rev=66ffb7d7a65d7251d0b47db9599d36cefc4d6703#66ffb7d7a65d7251d0b47db9599d36cefc4d6703"
+source = "git+https://github.com/hpm-rs/hpm-rt.git?rev=f9dd2f2122630ebfa8d9b96f539aba8be1c92784#f9dd2f2122630ebfa8d9b96f539aba8be1c92784"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ hpm-metapac = { version = "0.0.3", git = "https://github.com/hpmicro-rs/hpm-meta
 ] }
 rustsbi = { version = "0.4.0-alpha.3", features = ["machine"] }
 sbi-spec = { version = "0.0.7", features = ["legacy"] }
-hpm-rt = { git = "https://github.com/hpm-rs/hpm-rt.git", rev = "66ffb7d7a65d7251d0b47db9599d36cefc4d6703" }
+hpm-rt = { git = "https://github.com/hpm-rs/hpm-rt.git", rev = "f9dd2f2122630ebfa8d9b96f539aba8be1c92784" }
 
 riscv = "0.10"
 spin = "0.9"
@@ -17,7 +17,7 @@ fast-trap = { version = "0.0.1", features = ["riscv-m"] }
 riscv-decode = { git = "https://github.com/fintelia/riscv-decode.git", rev = "349b2a6b9fa608fc427aa46eaef8935557510d28" }
 
 [build-dependencies]
-hpm-rt = { git = "https://github.com/hpm-rs/hpm-rt.git", rev = "66ffb7d7a65d7251d0b47db9599d36cefc4d6703" }
+hpm-rt = { git = "https://github.com/hpm-rs/hpm-rt.git", rev = "f9dd2f2122630ebfa8d9b96f539aba8be1c92784" }
 
 [features]
 ram = []

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -39,6 +39,7 @@ macro_rules! println {
 
 pub fn board_init() {
     hpm_rt::cache::icache_enable();
+    hpm_rt::cache::dcache_enable();
 
     let clock = unsafe { ClockConfigurator::new(pac::SYSCTL, pac::PLLCTL).freeze() };
 


### PR DESCRIPTION
## Describe

Since https://github.com/hpm-rs/hpm-rt/pull/11 fixed the d-cache problem when accessing SDRAM, enabling d-cache speeds up SDRAM memory access and improves performance.

Here is `ramspeed` test result:

```
~ # ramspeed -b 2 -g 1 -m 1 -r
RAMspeed (GENERIC) v2.6.0 by Rhett M. Hollander and Paul V. Bolotoff, 2002-09

1Gb per pass mode

INTEGER & READING         1 Kb block: 1469.35 Mb/s
INTEGER & READING         2 Kb block: 1485.96 Mb/s
INTEGER & READING         4 Kb block: 1498.95 Mb/s
INTEGER & READING         8 Kb block: 1504.50 Mb/s
INTEGER & READING        16 Kb block: 1506.97 Mb/s
INTEGER & READING        32 Kb block: 1304.37 Mb/s
INTEGER & READING        64 Kb block: 116.81 Mb/s
INTEGER & READING       128 Kb block: 116.84 Mb/s
INTEGER & READING       256 Kb block: 116.90 Mb/s
INTEGER & READING       512 Kb block: 116.84 Mb/s
INTEGER & READING      1024 Kb block: 116.90 Mb/s
```

## Other

Resolves #4 