### PR TITLE
build: update riscv-decode to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,8 +140,9 @@ dependencies = [
 
 [[package]]
 name = "riscv-decode"
-version = "0.2.1"
-source = "git+https://github.com/fintelia/riscv-decode.git?rev=349b2a6b9fa608fc427aa46eaef8935557510d28#349b2a6b9fa608fc427aa46eaef8935557510d28"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8b4cfb0da0528321d22daee4299a23a8c5ac8848623d716e898d2a9eec0694"
 
 [[package]]
 name = "riscv-rt-macros"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ hpm-rt = { git = "https://github.com/hpm-rs/hpm-rt.git", rev = "f9dd2f2122630ebf
 riscv = "0.10"
 spin = "0.9"
 fast-trap = { version = "0.0.1", features = ["riscv-m"] }
-riscv-decode = { git = "https://github.com/fintelia/riscv-decode.git", rev = "349b2a6b9fa608fc427aa46eaef8935557510d28" }
+riscv-decode = "0.2.2"
 
 [build-dependencies]
 hpm-rt = { git = "https://github.com/hpm-rs/hpm-rt.git", rev = "f9dd2f2122630ebfa8d9b96f539aba8be1c92784" }


### PR DESCRIPTION
Update riscv-decode to 0.2.2 to get RVA decoding support.